### PR TITLE
Updates to URL loading

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -381,6 +381,11 @@ function kws_yourls_add_analytics_tracking_code($return, $keyword, $field, $notf
 	
 	// If we are working with a long URL, then let's get to it!
 	$url = $return;
+
+	// Don't create a non-empty URL from an empty URL (i.e. one that was not in the database) since YOURLS depends on emptiness in yourls-go.php
+	if (empty($url)) {
+		return $return;
+	}
 	
 	$parsed = parse_url($url);
 		$parsed['scheme'] = isset($parsed['scheme']) ? $parsed['scheme'] : 'http';


### PR DESCRIPTION
Hello,

Thanks for creating this plugin. It will be very helpful here at the University of Florida.

In my testing I ran into a couple of problems:
- The loader_failed hook was conflicting with another plugin I'm using to generate 404 errors on invalid keywords. When the 404 plugin was disabled, it didn't seem like your loader_failed hook was doing much on YOURLS trunk.
- The get_keyword_info hook was incorrectly returning a string "http://" when YOURLS did not already have a URL in its database for the keyword. This caused yourls-go.php to think that a URL did exist, and thus generate a redirect to an invalid location.

Thanks again for your work! I hope these commits are helpful.
