### PR TITLE
Fixed jQuery error

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -339,7 +339,7 @@ function add() {
 }
 
 	jQuery(document).ready(function($){
-		$('a.toggle').live('load click', function(e) {
+		$('a.toggle').on('click', null, function(e) {
 			e.preventDefault();
 			var $div = $($(this).attr('href'));
 			var $that = $(this);


### PR DESCRIPTION
Hello!  Thanks for the great plugin.

Using YOURLS version 1.7-alpha and the latest of this plugin, I found that I get a Javascript error and the "Show descriptions of these terms" link (on the plugin's settings page) is not functional.  Although I have not verified, my guess is that YOURLS jQuery version was upgraded, causing an error upon calling the live function.  Rather than complain, I figured I'd fix it!
